### PR TITLE
Removed some calls to str() for playing nice with Python3.

### DIFF
--- a/abf/macho.py
+++ b/abf/macho.py
@@ -196,7 +196,7 @@ class MACHO:
                             'offset'  : section.offset,
                             'size'    : section.size,
                             'vaddr'   : section.addr,
-                            'opcodes' : str(self.__binary[section.offset:section.offset+section.size])
+                            'opcodes' : self.__binary[section.offset:section.offset+section.size]
                         }]
         return ret
 
@@ -210,7 +210,7 @@ class MACHO:
                             'offset'  : section.offset,
                             'size'    : section.size,
                             'vaddr'   : section.addr,
-                            'data'    : str(self.__binary[section.offset:section.offset+section.size])
+                            'data'    : self.__binary[section.offset:section.offset+section.size]
                         }]
         return ret
 

--- a/abf/pe.py
+++ b/abf/pe.py
@@ -15,7 +15,7 @@
 from abf.cpu        import *
 from abf.exception  import *
 from ctypes         import *
-from struct         import unpack
+from struct         import unpack_from
 
 
 
@@ -176,7 +176,7 @@ class PE:
 
 
     def __getPEOffset(self):
-        self.__PEOffset = unpack('<I', str(self.__binary[60:64]))[0]
+        self.__PEOffset = unpack_from('<I', self.__binary[60:64])[0]
         if self.__binary[self.__PEOffset:self.__PEOffset+4] != b'\x50\x45\x00\x00':
             raise AbfException('PE.__getPEOffset() - Bad PE signature')
 
@@ -189,10 +189,10 @@ class PE:
     def __parseOptHeader(self):
         PEoptHeader = self.__binary[self.__PEOffset+24:self.__PEOffset+24+self.__IMAGE_FILE_HEADER.SizeOfOptionalHeader]
 
-        if unpack('<H', str(PEoptHeader[0:2]))[0] == PEFlags.IMAGE_NT_OPTIONAL_HDR32_MAGIC:
+        if unpack_from('<H', PEoptHeader[0:2])[0] == PEFlags.IMAGE_NT_OPTIONAL_HDR32_MAGIC:
             self.__IMAGE_OPTIONAL_HEADER = IMAGE_OPTIONAL_HEADER.from_buffer_copy(PEoptHeader)
 
-        elif unpack('<H', str(PEoptHeader[0:2]))[0] == PEFlags.IMAGE_NT_OPTIONAL_HDR64_MAGIC:
+        elif unpack_from('<H', PEoptHeader[0:2])[0] == PEFlags.IMAGE_NT_OPTIONAL_HDR64_MAGIC:
             self.__IMAGE_OPTIONAL_HEADER = IMAGE_OPTIONAL_HEADER64.from_buffer_copy(PEoptHeader)
 
         else:
@@ -225,7 +225,7 @@ class PE:
                             'offset'  : section.PointerToRawData,
                             'size'    : section.SizeOfRawData,
                             'vaddr'   : section.VirtualAddress + self.__IMAGE_OPTIONAL_HEADER.ImageBase,
-                            'data' : str(self.__binary[section.PointerToRawData:section.PointerToRawData+section.SizeOfRawData])
+                            'data'    : self.__binary[section.PointerToRawData:section.PointerToRawData+section.SizeOfRawData]
                         }]
         return ret
 
@@ -239,7 +239,7 @@ class PE:
                             'offset'  : section.PointerToRawData,
                             'size'    : section.SizeOfRawData,
                             'vaddr'   : section.VirtualAddress + self.__IMAGE_OPTIONAL_HEADER.ImageBase,
-                            'opcodes'    : str(self.__binary[section.PointerToRawData:section.PointerToRawData+section.SizeOfRawData])
+                            'opcodes' : self.__binary[section.PointerToRawData:section.PointerToRawData+section.SizeOfRawData]
                         }]
         return ret
 


### PR DESCRIPTION
Thought I checked everything on the previous patch but I forgot stuff. my bad.

I'm not quite sure why you would want to have opcodes and data as `str()` specifically and not rely on what is returned by the read on the binary mode file? Not doing this lets us have proper bytes in Python 3.

I also prefer to use unpack_from even if it isn't necessary in this case, because that allows you to do `unpack_from("<B", foobar[offset:])`, which wouldn't work with a simple unpack because then the single byte `foobar[offset:offset+1]` will be considered an `int` which doesn't have the buffer interface. (This is also what I did on the previous pull request)
